### PR TITLE
use `map` instead of `forEach`

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -11,7 +11,7 @@ const get = () => {
     .get(`${url}?repo=${repo}&token=${token}`)
     .then(response => {
       const values = {}
-      response.data.map(file => (values[file.path] = file.size))
+      response.data.forEach(file => (values[file.path] = file.size))
       return values
     })
     .catch(error => console.log(error))


### PR DESCRIPTION
use `map` instead of `forEach` if not returning a new array.