### PR TITLE
Rename 'threshold' to 'maxSize', with backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add it to your scripts in `package.json`
 
 &nbsp;
 
-1) Add the path and threshold in your `package.json`
+1) Add the path and maxSize in your `package.json`
 
 
 ```json
@@ -45,7 +45,7 @@ Add it to your scripts in `package.json`
   "bundlesize": [
     {
       "path": "./dist.js",
-      "threshold": "3 Kb"
+      "maxSize": "3 Kb"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "size",
     "check",
     "build",
-    "threshold"
+    "maxSize"
   ],
   "files": [
     "index.js",
@@ -32,7 +32,8 @@
   "bundlesize": [
     {
       "path": "./index.js",
-      "threshold": "600B"
+      "threshold": "600B",
+      "maxSize": "600B"
     }
   ]
 }

--- a/src/files.js
+++ b/src/files.js
@@ -10,8 +10,8 @@ config.map(file => {
   const paths = glob.sync(file.path)
   paths.map(path => {
     const size = gzip.sync(fs.readFileSync(path, 'utf8'))
-    const threshold = bytes(file.threshold)
-    files.push({ threshold, path, size })
+    const maxSize = bytes(file.threshold || file.maxSize)
+    files.push({ maxSize, path, size })
   })
 })
 

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -11,25 +11,25 @@ const compare = (files, masterValues = {}) => {
   files.map(file => (file.master = masterValues[file.path]))
 
   files.map(file => {
-    const { path, size, master, threshold } = file
+    const { path, size, master, maxSize } = file
 
     let message = `${path}: ${bytes(size)} `
 
     /*
-      if size > threshold, fail
+      if size > maxSize, fail
       else if size > master, warn + pass
       else yay + pass
     */
 
-    if (size > threshold) {
+    if (size > maxSize) {
       fail = true
-      message += `> threshold ${bytes(threshold)} gzip`
+      message += `> maxSize ${bytes(maxSize)} gzip`
       error(message, { fail: false, label: 'FAIL' })
     } else if (!master) {
-      message += `< threshold ${bytes(threshold)} gzip`
+      message += `< maxSize ${bytes(maxSize)} gzip`
       info('PASS', message)
     } else {
-      message += `< threshold ${bytes(threshold)} gzip `
+      message += `< maxSize ${bytes(maxSize)} gzip `
       const diff = size - master
 
       if (diff < 0) {
@@ -47,14 +47,14 @@ const compare = (files, masterValues = {}) => {
     }
   })
 
-  if (fail) build.fail(globalMessage || 'bundle size > threshold')
+  if (fail) build.fail(globalMessage || 'bundle size > maxSize')
   else {
     if (event_type === 'push' && branch === 'master') {
       const values = []
       files.map(file => values.push({ path: file.path, size: file.size }))
       api.set(values)
     }
-    build.pass(globalMessage || 'Good job! bundle size < threshold')
+    build.pass(globalMessage || 'Good job! bundle size < maxSize')
   }
 }
 


### PR DESCRIPTION
rename `threshold` to `maxSize` with backward compatibility.

fix for #14 