### PR TITLE
thorw an error if maxSize not specified

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -10,7 +10,7 @@ config.map(file => {
   const paths = glob.sync(file.path)
   paths.map(path => {
     const size = gzip.sync(fs.readFileSync(path, 'utf8'))
-    const maxSize = bytes(file.threshold || file.maxSize)
+    const maxSize = bytes(file.threshold || file.maxSize) || null
     files.push({ maxSize, path, size })
   })
 })

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -23,7 +23,7 @@ const compare = (files, masterValues = {}) => {
 
     if (!maxSize) {
       fail = true
-      message += 'maxSize not specified'
+      message = 'maxSize not specified'
       error(message, { fail: false, label: 'FAIL' })
     } else if (size > maxSize) {
       fail = true

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -16,24 +16,22 @@ const compare = (files, masterValues = {}) => {
     let message = `${path}: ${bytes(size)} `
 
     /*
-      if size > maxSize, fail
+      if !maxSize, return warn + pass
+      else if size > maxSize, fail
       else if size > master, warn + pass
       else yay + pass
     */
 
     if (!maxSize) {
       fail = true
-      message = 'maxSize not specified'
-      error(message, { fail: false, label: 'FAIL' })
+      message += '( maxSize not specified )'
+      info('WARN', message)
     } else if (size > maxSize) {
       fail = true
-      message += `> maxSize ${bytes(maxSize)} gzip`
       error(message, { fail: false, label: 'FAIL' })
     } else if (!master) {
-      message += `< maxSize ${bytes(maxSize)} gzip`
       info('PASS', message)
     } else {
-      message += `< maxSize ${bytes(maxSize)} gzip `
       const diff = size - master
 
       if (diff < 0) {

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -21,7 +21,11 @@ const compare = (files, masterValues = {}) => {
       else yay + pass
     */
 
-    if (size > maxSize) {
+    if (!maxSize) {
+      fail = true
+      message += 'maxSize not specified'
+      error(message, { fail: false, label: 'FAIL' })
+    } else if (size > maxSize) {
       fail = true
       message += `> maxSize ${bytes(maxSize)} gzip`
       error(message, { fail: false, label: 'FAIL' })


### PR DESCRIPTION
Right now, we are not checking for maxSize is `null` or not.

This PR adds a `null` if maxSize is not specified and will throw an error saying `maxSize not specified`.