### PR TITLE
Add npm banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 &nbsp;
 
 [![Build Status](https://travis-ci.org/siddharthkp/bundlesize.svg?branch=master)](https://travis-ci.org/siddharthkp/bundlesize)
+[![NPM Version](https://img.shields.io/npm/v/bundlesize.svg)](https://npmjs.org/package/bundlesize)
 
 &nbsp;
 


### PR DESCRIPTION
Added mainly to act as a link to the npm package page. (which is good for showing usage of the package). Also shows the latest version number.

[visual diff](https://github.com/danyshaanan/bundlesize/commit/a1a91782bedbee44350b2583e6ef3e985ae9bb7b?short_path=04c6e90).