### PR TITLE
change token to be prefixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Add it to your scripts in `package.json`
 Currently works for [Travis CI](https://travis-ci.org) and [CircleCI](https://circleci.com/).
 
 - [Authorize `bundlesize` for status access](https://github.com/login/oauth/authorize?scope=repo%3Astatus&client_id=6756cb03a8d6528aca5a), copy the token provided.
-- Add this token as `github_token` as environment parameter in your CIs project settings.
+- Add this token as `bundlesize_github_token` as environment parameter in your CIs project settings.
 - On travis-ci: Enable `Build branch updates` and `Build pull request updates`. ([screenshot](https://raw.githubusercontent.com/siddharthkp/bundlesize/master/art/travis.png))
 - On CircleCi: Enable `GitHub Status updates` in your advanced project settings (this should be enabled by default).
 

--- a/src/environment.js
+++ b/src/environment.js
@@ -1,27 +1,36 @@
 let environment;
 
+// prefer prefix token name and back support github_token
+const token =
+  process.env.bundlesize_github_token ||
+  process.env.BUNDLESIZE_GITHUB_TOKEN ||
+  process.env.github_token ||
+  process.env.GITHUB_TOKEN;
+
 // Use CircleCi's env variables if detected.
 // See https://circleci.com/docs/1.0/environment-variables/ for reference.
 if (process.env.CIRCLECI) {
   environment = {
-    repo: `${process.env.CIRCLE_PROJECT_USERNAME}/${process.env.CIRCLE_PROJECT_REPONAME}`,
-    token: process.env.github_token || process.env.GITHUB_TOKEN,
+    repo: `${process.env.CIRCLE_PROJECT_USERNAME}/${process.env
+      .CIRCLE_PROJECT_REPONAME}`,
+    token,
     // Circle doesn't have the EVENT_TYPE information so we default to 'pull_request'.
-    event_type: 'pull_request',
+    event_type: "pull_request",
     sha: process.env.CIRCLE_SHA1,
-    branch: process.env.CIRCLE_BRANCH
+    branch: process.env.CIRCLE_BRANCH,
   };
 } else {
   // Default to travis
   // See https://docs.travis-ci.com/user/environment-variables/ for reference.
   environment = {
     repo: process.env.TRAVIS_REPO_SLUG,
-    token: process.env.github_token || process.env.GITHUB_TOKEN,
+    token,
     event_type: process.env.TRAVIS_EVENT_TYPE,
     sha: process.env.TRAVIS_PULL_REQUEST_SHA || process.env.TRAVIS_COMMIT,
-    branch: process.env.TRAVIS_EVENT_TYPE === 'push'
-      ? process.env.TRAVIS_BRANCH
-      : process.env.TRAVIS_PULL_REQUEST_BRANCH
+    branch:
+      process.env.TRAVIS_EVENT_TYPE === "push"
+        ? process.env.TRAVIS_BRANCH
+        : process.env.TRAVIS_PULL_REQUEST_BRANCH,
   };
 }
 


### PR DESCRIPTION
`github_token` can conflict with other tools that use the same identifier on the CI. This PR adjusts it to prefer `bundlesize_github_token` with backwards support for `github_token`.

@siddharthkp this is such a great tool! Thank you!