### PR TITLE
Make max size optional

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -17,7 +17,7 @@ program
 
 let cliConfig
 
-if (program.files && program.maxSize) {
+if (program.files) {
   cliConfig = [
     {
       path: program.files,

--- a/src/files.js
+++ b/src/files.js
@@ -15,7 +15,7 @@ config.map(file => {
   } else {
     paths.map(path => {
       const size = gzip.sync(fs.readFileSync(path, 'utf8'))
-      const maxSize = bytes(file.threshold || file.maxSize)
+      const maxSize = bytes(file.threshold || file.maxSize) || Infinity
       files.push({ maxSize, path, size })
     })
   }

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -15,7 +15,7 @@ const compare = (files, masterValues = {}) => {
     const { path, size, master, maxSize } = file
 
     let message = `${path}: ${bytes(size)} `
-
+    const prettySize = bytes(maxSize)
     /*
       if size > maxSize, fail
       else if size > master, warn + pass
@@ -24,13 +24,13 @@ const compare = (files, masterValues = {}) => {
 
     if (size > maxSize) {
       fail = true
-      message += `> maxSize ${bytes(maxSize)} gzip`
+      if (prettySize) message += `> maxSize ${prettySize} gzip`
       error(message, { fail: false, label: 'FAIL' })
     } else if (!master) {
-      message += `< maxSize ${bytes(maxSize)} gzip`
+      if (prettySize) message += `< maxSize ${prettySize} gzip`
       info('PASS', message)
     } else {
-      message += `< maxSize ${bytes(maxSize)} gzip `
+      if (prettySize) message += `< maxSize ${prettySize} gzip `
       const diff = size - master
 
       if (diff < 0) {


### PR DESCRIPTION
Now you can configure `bundlesize` with path alone.

```
"bundlesize": [
    { "path": "./index.js" }
  ]
```
or 
```
bundlesize -f index.js
```

This means your build will always pass, but it will give the comparison with `master` as a message/warning.