### PR TITLE
Fix path of require statement

### DIFF
--- a/src/init-status.js
+++ b/src/init-status.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-const build = require('./src/build')
+const build = require('./build')


### PR DESCRIPTION
Currently if you run `bundlesize-init` you get:

```
Error: Cannot find module './src/build'
```