### PR TITLE
Update css to break filenames correctly

### DIFF
--- a/store/static/styles.css
+++ b/store/static/styles.css
@@ -42,6 +42,7 @@ body {
 }
 .file > div {
   display: inline-block;
+  word-wrap: break-word;
 }
 .path {
   width: 20%;


### PR DESCRIPTION
Before:

<img width="1194" alt="screen shot 2017-07-26 at 6 01 00 pm" src="https://user-images.githubusercontent.com/1824298/28621354-4df3d186-722e-11e7-85e4-8cf82cc30722.png">

After:

<img width="1193" alt="screen shot 2017-07-26 at 6 00 41 pm" src="https://user-images.githubusercontent.com/1824298/28621371-55e92026-722e-11e7-8ff7-4c80d048e74c.png">
