### PR TITLE
Use goo.gl shortener for urls > 1024

### DIFF
--- a/src/shortener.js
+++ b/src/shortener.js
@@ -1,0 +1,18 @@
+const axios = require('axios');
+
+const googleApiKey = ''
+const url = 'https://www.googleapis.com/urlshortener/v1/url'
+
+const shorten = (longUrl) => {
+  return axios({
+    method: 'POST',
+    url: `${url}?key=${googleApiKey}`,
+    data: {
+      longUrl
+    }
+  })
+}
+
+const shortener = { shorten }
+
+module.exports = shortener;


### PR DESCRIPTION
I realised today that we could just shorten the url before sending it off to the github build status api.

The reason why storing it in firebase (as mentioned in #80) wont work as easily was because we might have to take backward compatibility into consideration and probably roll out a v2 for `/build` endpoint to tackle the older query-string and newer hash implementation.

The implementation below shortens the url (using the [google shortener api](https://developers.google.com/url-shortener/v1/getting_started#shorten)) which crosses 1024 chars. ~~You'll need to [get the API Key](https://developers.google.com/url-shortener/v1/getting_started#APIKey) and add it under the `@bundlesize_googleapikey` secret to your zeit/now settings.~~

Let me know what you think.
