### PR TITLE
Use correct capitalisation for "kB" in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ npx bundlesize
   "bundlesize": [
     {
       "path": "./dist.js",
-      "maxSize": "3 Kb"
+      "maxSize": "3 kB"
     }
   ]
 }
@@ -66,11 +66,11 @@ Example:
 "bundlesize": [
   {
     "path": "./dist/vendor-*.js",
-    "maxSize": "3 Kb"
+    "maxSize": "3 kB"
   },
   {
     "path": "./dist/chunk-*.js",
-    "maxSize": "3 Kb"
+    "maxSize": "3 kB"
   }
 ]
 


### PR DESCRIPTION
It should probably be `kB` or `KB` (for 1000 or 1024 bytes respectively). `Kb` is mixed-case without really meaning anything