### PR TITLE
Add "similar projects" section to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ For more granular configuration, we recommend configuring it in the `package.jso
 
 &nbsp;
 
+#### similar projects
+
+- [BuildSize](https://buildsize.org/) - GitHub App, no manual configuration required
+- [travis-weigh-in](https://github.com/danvk/travis-weigh-in) - Uses Python rather than Node.js
+
 #### license
 
 MIT © [siddharthkp](https://github.com/siddharthkp)


### PR DESCRIPTION
## Description
There's a few similar projects to bundlesize, so it would be good to compare them in the readme. `travis-weigh-in` is one I've seen used in the past, and it's existed for a while longer than bundlesize has.

Recently I started building https://buildsize.org/ which takes a different approach: Rather than requiring a build-time dependency to be added, it's configured as a webhook via a GitHub App. This means that (at least at the moment) it only supports CI systems that support archiving of artifacts (such as CircleCI and AppVeyor), but on the other hand it means that no additional configuration is required, and no additional software is needed. You just add the webhook and it automatically tracks all artifacts. This is quite a departure from how bundlesize works so I figured I'd spin up a project to experiment with some ideas.

For Yarn we use two different build systems (CircleCI for the Linux build, and AppVeyor for the Windows build), and having a build-time script do the measurement would make it a bit trickier to aggregate the data from the two build systems into a single build status / comment.

Each approach has its own advantages and disadvantages. Since bundlesize just checks the file sizes on the file system, it can likely work with **any** continuous integration system. However, that also means that it needs to be configured per use-case. I call out bundlesize as a similar project in my readme, and started writing a comparison at https://github.com/Daniel15/BuildSize/blob/master/docs/comparison.md, but that's likely biased so I'd be happy to share notes with you and adjust the document accordingly. I think it's good for multiple projects to exist, as people can compare them and pick the one that suits their needs best.

Of course, feel free to disagree and close this PR without merging it if you want. 😃 

## Types of changes
N/A (documentation)
