### PR TITLE
Fix compare to master files

### DIFF
--- a/src/reporter.js
+++ b/src/reporter.js
@@ -32,8 +32,8 @@ const compare = (files, masterValues = {}) => {
   let globalMessage
 
   files.map(file => {
-    const { path, size, master, maxSize } = file
     file.master = masterValues[file.path]
+    const { path, size, master, maxSize } = file
 
     let message = `${path}: ${bytes(size)} `
     const prettySize = bytes(maxSize)

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -11,8 +11,8 @@ const setBuildStatus = ({
   files,
   globalMessage,
   fail,
-  currentEvent,
-  currentBranch
+  event: currentEvent,
+  branch: currentBranch
 }) => {
   if (fail) build.fail(globalMessage || 'bundle size > maxSize', url)
   else {


### PR DESCRIPTION
Comparing with master files does not seem to be working bec:
1. When checking if there are master files [here](https://github.com/siddharthkp/bundlesize/blob/master/src/reporter.js#L50), the destructed variable `master` is being used for this check. That variable was set [before setting master on it](https://github.com/siddharthkp/bundlesize/blob/master/src/reporter.js#L36). Fixed this by moving the destructing of `files` to after master was already set on it.
2. In the [setBuildStatus function](https://github.com/siddharthkp/bundlesize/blob/master/src/reporter.js#L9), the name of the params of the function do not match the object that is being sent it. Fixed the names of it.