### PR TITLE
add --check option

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,12 +2,13 @@ module.exports = {
   extends: ['prettier', 'standard'],
   plugins: ['prettier', 'node'],
   rules: {
+    "space-before-function-paren": 0, // only here because prettier fails if you correct this
     'prettier/prettier': [
       'error',
       {
         singleQuote: true,
         semi: false,
-      },
+      }
     ],
   },
 };

--- a/src/config.js
+++ b/src/config.js
@@ -11,7 +11,6 @@ const packageJSONconfig = pkg.bundlesize
 /* Config from CLI */
 
 program
-  .option('-c, --check', 'do a simple check for the size of the file(s)')
   .option('-f, --files [files]', 'files to test against (dist/*.js)')
   .option('-s, --max-size [maxSize]', 'maximum size threshold (3Kb)')
   .option('--debug', 'run in debug mode')
@@ -23,8 +22,7 @@ if (program.files) {
   cliConfig = [
     {
       path: program.files,
-      maxSize: program.maxSize,
-      check: program.check || !program.maxSize
+      maxSize: program.maxSize
     }
   ]
 }

--- a/src/config.js
+++ b/src/config.js
@@ -11,6 +11,7 @@ const packageJSONconfig = pkg.bundlesize
 /* Config from CLI */
 
 program
+  .option('-c, --check', 'do a simple check for the size of the file(s)')
   .option('-f, --files [files]', 'files to test against (dist/*.js)')
   .option('-s, --max-size [maxSize]', 'maximum size threshold (3Kb)')
   .option('--debug', 'run in debug mode')
@@ -22,7 +23,8 @@ if (program.files) {
   cliConfig = [
     {
       path: program.files,
-      maxSize: program.maxSize
+      maxSize: program.maxSize,
+      check: program.check || !program.maxSize
     }
   ]
 }

--- a/src/files.js
+++ b/src/files.js
@@ -17,9 +17,8 @@ config.map(file => {
   } else {
     paths.map(path => {
       const size = gzip.sync(fs.readFileSync(path, 'utf8'))
-      const maxSize = bytes(file.maxSize) || Infinity
-      const check = file.check
-      files.push({ maxSize, path, size, check })
+      const maxSize = bytes(file.maxSize) || false
+      files.push({ maxSize, path, size })
     })
   }
 })

--- a/src/files.js
+++ b/src/files.js
@@ -18,7 +18,8 @@ config.map(file => {
     paths.map(path => {
       const size = gzip.sync(fs.readFileSync(path, 'utf8'))
       const maxSize = bytes(file.maxSize) || Infinity
-      files.push({ maxSize, path, size })
+      const check = file.check
+      files.push({ maxSize, path, size, check })
     })
   }
 })

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,5 +1,5 @@
 const bytes = require('bytes')
-const { error, warn, info } = require('prettycli')
+const { error, warn, info, loading } = require('prettycli')
 const { event, repo, branch, commit_message, sha } = require('ci-env')
 const build = require('./build')
 const api = require('./api')
@@ -33,7 +33,7 @@ const compare = (files, masterValues = {}) => {
 
   files.map(file => {
     file.master = masterValues[file.path]
-    const { path, size, master, maxSize } = file
+    const { path, size, master, maxSize, check } = file
 
     let message = `${path}: ${bytes(size)} `
     const prettySize = bytes(maxSize)
@@ -43,7 +43,10 @@ const compare = (files, masterValues = {}) => {
       else yay + pass
     */
 
-    if (size > maxSize) {
+    if (check) {
+      // just checking sizes here, no passing or failing
+      loading('CHECK', message)
+    } else if (size > maxSize) {
       fail = true
       if (prettySize) message += `> maxSize ${prettySize} gzip`
       error(message, { fail: false, label: 'FAIL' })

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,5 +1,5 @@
 const bytes = require('bytes')
-const { error, warn, info, loading } = require('prettycli')
+const { error, warn, info } = require('prettycli')
 const { event, repo, branch, commit_message, sha } = require('ci-env')
 const build = require('./build')
 const api = require('./api')
@@ -33,7 +33,7 @@ const compare = (files, masterValues = {}) => {
 
   files.map(file => {
     file.master = masterValues[file.path]
-    const { path, size, master, maxSize, check } = file
+    const { path, size, master, maxSize } = file
 
     let message = `${path}: ${bytes(size)} `
     const prettySize = bytes(maxSize)
@@ -43,9 +43,9 @@ const compare = (files, masterValues = {}) => {
       else yay + pass
     */
 
-    if (check) {
+    if (!maxSize) {
       // just checking sizes here, no passing or failing
-      loading('CHECK', message)
+      console.log(message)
     } else if (size > maxSize) {
       fail = true
       if (prettySize) message += `> maxSize ${prettySize} gzip`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- adds an additional option for checking a file's size without passing or failing it

- not passing a `maxsize` option does `--check` automatically
<!--- Describe your changes  -->

## Motivation and Context

running bundlesize command without passing a maxsize `-s`, will show the "PASS" label which is misleading.

Sometimes you may just want to run bundlesize to get a quick size check of a file.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

![bundlesize1](https://user-images.githubusercontent.com/9396189/31305580-c27a2a5c-ab02-11e7-9e5c-4dd9612a4ce7.png)

![bundlesize2](https://user-images.githubusercontent.com/9396189/31305582-c52813c2-ab02-11e7-8e7c-fa820ddd91f2.png)


## Types of changes

<!--- Leave the one fitting to your PR  -->
- New feature (non-breaking change which adds functionality)


## Checklist:

<!--- Go over all the following points and make sure you have done all of those -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- My code follows the code style of this project.
- If my change requires a change to the documentation I have updated the documentation accordingly.
- I have read the **CONTRIBUTING** document.
- I created an issue for the Pull Request
