### PR TITLE
Add 'displayName' config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npx bundlesize
 
 &nbsp;
 
-#### 1) Add the path and gzip maxSize in your `package.json`
+#### 1) Add the path and gzip maxSize in your `package.json`. 
 
 ```json
 {
@@ -80,6 +80,19 @@ Example:
 ```
 
 This makes it great for using with applications that are bundled with another tool. It will match multiple files if necessary and create a new row for each file.
+
+You may optionally add a `displayName` property to customize the filename that gets posted to the Github status. For example, if the filepath is long and gets truncated on Github, you can input a custom display name.
+
+```json
+"bundlesize": [
+  {
+    "path": "./packages/more-subdirectories/long-filename.bundle.js",
+    "maxSize": "3 kB",
+    "displayName": "bundle.js"
+  }
+]
+
+```
 
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npx bundlesize
 
 &nbsp;
 
-#### 1) Add the path and gzip maxSize in your `package.json`. 
+#### 1) Add the path and gzip maxSize in your `package.json`
 
 ```json
 {

--- a/src/config.js
+++ b/src/config.js
@@ -13,6 +13,10 @@ const packageJSONconfig = pkg.bundlesize
 program
   .option('-f, --files [files]', 'files to test against (dist/*.js)')
   .option('-s, --max-size [maxSize]', 'maximum size threshold (3Kb)')
+  .option(
+    '-n, --display-name [displayName]',
+    'filename to display on Github UI'
+  )
   .option('--debug', 'run in debug mode')
   .parse(process.argv)
 
@@ -22,7 +26,8 @@ if (program.files) {
   cliConfig = [
     {
       path: program.files,
-      maxSize: program.maxSize
+      maxSize: program.maxSize,
+      displayName: program.displayName
     }
   ]
 }

--- a/src/config.js
+++ b/src/config.js
@@ -13,10 +13,7 @@ const packageJSONconfig = pkg.bundlesize
 program
   .option('-f, --files [files]', 'files to test against (dist/*.js)')
   .option('-s, --max-size [maxSize]', 'maximum size threshold (3Kb)')
-  .option(
-    '-n, --display-name [displayName]',
-    'filename to display on Github UI'
-  )
+  .option('-n, --display-name [displayName]', 'filename to display on Github UI')
   .option('--debug', 'run in debug mode')
   .parse(process.argv)
 

--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,9 @@ const packageJSONconfig = pkg.bundlesize
 program
   .option('-f, --files [files]', 'files to test against (dist/*.js)')
   .option('-s, --max-size [maxSize]', 'maximum size threshold (3Kb)')
-  .option('-n, --display-name [displayName]', 'filename to display on Github UI')
+  .option(
+    '-n, --display-name [displayName]', 
+    'filename to display on Github UI')
   .option('--debug', 'run in debug mode')
   .parse(process.argv)
 

--- a/src/config.js
+++ b/src/config.js
@@ -14,7 +14,8 @@ program
   .option('-f, --files [files]', 'files to test against (dist/*.js)')
   .option('-s, --max-size [maxSize]', 'maximum size threshold (3Kb)')
   .option(
-    '-n, --display-name [displayName]', 
+    '-n, 
+    --display-name [displayName]',
     'filename to display on Github UI')
   .option('--debug', 'run in debug mode')
   .parse(process.argv)

--- a/src/config.js
+++ b/src/config.js
@@ -14,8 +14,7 @@ program
   .option('-f, --files [files]', 'files to test against (dist/*.js)')
   .option('-s, --max-size [maxSize]', 'maximum size threshold (3Kb)')
   .option(
-    '-n, 
-    --display-name [displayName]',
+    '-n, --display-name [displayName]',
     'filename to display on Github UI')
   .option('--debug', 'run in debug mode')
   .parse(process.argv)

--- a/src/files.js
+++ b/src/files.js
@@ -18,7 +18,7 @@ config.map(file => {
     paths.map(path => {
       const size = gzip.sync(fs.readFileSync(path, 'utf8'))
       const maxSize = bytes(file.maxSize) || Infinity
-      files.push({ maxSize, path, size })
+      files.push({ maxSize, path, size, displayName: file.displayName })
     })
   }
 })

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -33,9 +33,11 @@ const compare = (files, masterValues = {}) => {
 
   files.map(file => {
     file.master = masterValues[file.path]
-    const { path, size, master, maxSize } = file
+    const { path, size, master, maxSize, displayName } = file
 
-    let message = `${path}: ${bytes(size)} `
+    const fileName = displayName || path
+
+    let message = `${fileName}: ${bytes(size)} `
     const prettySize = bytes(maxSize)
     /*
       if size > maxSize, fail


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added optional config setting for `displayName`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If a filename or filepath is long, it gets truncated from the Github status that is posted. Allowing an optional displayName option allows users to specify the filename they want to use.

See  #161 and also #72. Note there is also discussion of automatically parsing long filenames, which I think is also a great idea, but the `displayName` option would allow additional customization and is optional, so it would not interfere with any other features if users do not want to provide a displayName.

## Screenshots (if appropriate):

## Types of changes

<!--- Leave the one fitting to your PR  -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!--- Go over all the following points and make sure you have done all of those -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- My code follows the code style of this project.
- If my change requires a change to the documentation I have updated the documentation accordingly.
- I have read the **CONTRIBUTING** document.
- I created an issue for the Pull Request
