### PR TITLE
Add support for disabling compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,27 @@ This makes it great for using with applications that are bundled with another to
 
 &nbsp;
 
-#### 2) build status
+#### 2) Disabling compression
+
+If you want to check the size of your bundle before compression, the `gzip` configuration option can be set to false (defaults to true):
+
+```json
+"bundlesize": [
+  {
+    "path": "./dist/vendor-*.js",
+    "maxSize": "3 kB",
+    "gzip": false
+  },
+  {
+    "path": "./dist/chunk-*.js",
+    "maxSize": "3 kB",
+    "gzip": false
+  }
+]
+
+```
+
+#### 3) build status
 
 ![build status](https://cdn.rawgit.com/siddharthkp/bundlesize/master/art/status.png)
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     },
     {
       "path": "./src/files.js",
-      "maxSize": "600B"
+      "maxSize": "1KB",
+      "gzip": false
     }
   ],
   "lint-staged": {

--- a/pipe.js
+++ b/pipe.js
@@ -9,17 +9,30 @@ const { error } = require('prettycli')
 const build = require('./src/build')
 const debug = require('./src/debug')
 
+const getSize = (data, gzipEnabled) => {
+  if (gzipEnabled) {
+    return gzip.sync(data)
+  } else {
+    return Buffer.byteLength(data)
+  }
+}
+
 if (process.stdin.isTTY) {
   error('bundlesize-pipe executable is meant for usage with piped data.')
 }
 
 program
+  .option(
+    '-g, --gzip [gzip]',
+    'compress bundle with gzip before testing (true)'
+  )
   .option('-n, --name [name]', 'custom name for a file (lib.min.js)')
   .option('-s, --max-size [maxSize]', 'maximum size threshold (3Kb)')
   .option('--debug', 'run in debug mode')
   .parse(process.argv)
 
 const config = {
+  gzip: program.gzip === undefined || program.gzip.toLowerCase() === 'true',
   name: program.name || require('read-pkg-up').sync().pkg.name,
   maxSize: program.maxSize
 }
@@ -28,12 +41,13 @@ debug('config', config)
 
 process.stdin.setEncoding('utf8')
 readStream(process.stdin).then(data => {
-  const size = gzip.sync(data)
+  const size = getSize(data, config.gzip)
   const maxSize = bytes(config.maxSize) || Infinity
   const file = {
     path: config.name,
     maxSize,
-    size
+    size,
+    gzip: config.gzip
   }
   debug('file', file)
   reporter([file])

--- a/src/config.js
+++ b/src/config.js
@@ -12,6 +12,10 @@ const packageJSONconfig = pkg.bundlesize
 
 program
   .option('-f, --files [files]', 'files to test against (dist/*.js)')
+  .option(
+    '-g, --gzip [gzip]',
+    'compress bundle with gzip before testing (true)'
+  )
   .option('-s, --max-size [maxSize]', 'maximum size threshold (3Kb)')
   .option('--debug', 'run in debug mode')
   .parse(process.argv)
@@ -22,7 +26,8 @@ if (program.files) {
   cliConfig = [
     {
       path: program.files,
-      maxSize: program.maxSize
+      maxSize: program.maxSize,
+      gzip: program.gzip === undefined || program.gzip.toLowerCase() === 'true'
     }
   ]
 }
@@ -41,9 +46,12 @@ if (!packageJSONconfig && !cliConfig) {
 }
 
 const config = cliConfig || packageJSONconfig
+const defaultedConfig = config.map(fileConfig =>
+  Object.assign({ gzip: true }, fileConfig)
+)
 
 debug('cli config', cliConfig)
 debug('package json config', packageJSONconfig)
 debug('selected config', config)
 
-module.exports = config
+module.exports = defaultedConfig

--- a/src/files.js
+++ b/src/files.js
@@ -8,6 +8,22 @@ const debug = require('./debug')
 
 const files = []
 
+const getFileSize = (path, gzipEnabled) => {
+  if (gzipEnabled) {
+    return gzip.sync(fs.readFileSync(path, 'utf8'))
+  } else {
+    return fs.statSync(path).size
+  }
+}
+
+const populateFileSizes = (paths, maxSize, gzipEnabled) => {
+  paths.forEach(path => {
+    const size = getFileSize(path, gzipEnabled)
+    const maxSizeBytes = bytes(maxSize) || Infinity
+    files.push({ maxSize: maxSizeBytes, path, size, gzip: gzipEnabled })
+  })
+}
+
 config.map(file => {
   const paths = glob.sync(file.path)
   if (!paths.length) {
@@ -15,11 +31,7 @@ config.map(file => {
       silent: true
     })
   } else {
-    paths.map(path => {
-      const size = gzip.sync(fs.readFileSync(path, 'utf8'))
-      const maxSize = bytes(file.maxSize) || Infinity
-      files.push({ maxSize, path, size })
-    })
+    populateFileSizes(paths, file.maxSize, file.gzip)
   }
 })
 

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -27,6 +27,10 @@ const setBuildStatus = ({
   debug('global message', globalMessage)
 }
 
+const generateMessage = (size, gzipEnabled) => {
+  return ` maxSize ${size} ${gzipEnabled ? 'gzip' : 'uncompressed'}`
+}
+
 const compare = (files, masterValues = {}) => {
   let fail = false
   let globalMessage
@@ -45,13 +49,13 @@ const compare = (files, masterValues = {}) => {
 
     if (size > maxSize) {
       fail = true
-      if (prettySize) message += `> maxSize ${prettySize} gzip`
+      if (prettySize) message += '>' + generateMessage(prettySize, file.gzip)
       error(message, { fail: false, label: 'FAIL' })
     } else if (!master) {
-      if (prettySize) message += `< maxSize ${prettySize} gzip`
+      if (prettySize) message += '<' + generateMessage(prettySize, file.gzip)
       info('PASS', message)
     } else {
-      if (prettySize) message += `< maxSize ${prettySize} gzip `
+      if (prettySize) message += '<' + generateMessage(prettySize, file.gzip)
       const diff = size - master
 
       if (diff < 0) {


### PR DESCRIPTION
## Description

Adds command line option and configuration option to disable gzip compression before comparison with target size.  Default is still to gzip.

## Motivation and Context

Sometimes gzipping of bundles cannot be guaranteed in production, or alternative compression options might be used. Fixes #139.

## Types of changes

- New feature (non-breaking change which adds functionality)
