### PR TITLE
feat: Add compression option (gzip|brotli|none)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,13 +36,14 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.17.0",
+    "brotli-size": "0.0.1",
     "bytes": "^3.0.0",
     "ci-env": "^1.4.0",
     "commander": "^2.11.0",
     "github-build": "^1.2.0",
     "glob": "^7.1.2",
-    "opencollective": "^1.0.3",
     "gzip-size": "^4.0.0",
+    "opencollective": "^1.0.3",
     "prettycli": "^1.4.3",
     "read-pkg-up": "^2.0.0"
   },

--- a/src/config.js
+++ b/src/config.js
@@ -13,6 +13,10 @@ const packageJSONconfig = pkg.bundlesize
 program
   .option('-f, --files [files]', 'files to test against (dist/*.js)')
   .option('-s, --max-size [maxSize]', 'maximum size threshold (3Kb)')
+  .option(
+    '-c, --compression [gzip|brotli|none]',
+    'specify which compression algorithm to use'
+  )
   .option('--debug', 'run in debug mode')
   .parse(process.argv)
 
@@ -22,7 +26,8 @@ if (program.files) {
   cliConfig = [
     {
       path: program.files,
-      maxSize: program.maxSize
+      maxSize: program.maxSize,
+      compression: program.compression || 'gzip'
     }
   ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added a `-c` or `--compression` option that accepts `gzip`, `brotli` or `none`

## Motivation and Context

This fixes #139 and also implements the brotli compression.

## Screenshots (if appropriate):

## Types of changes

<!--- Leave the one fitting to your PR  -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!--- Go over all the following points and make sure you have done all of those -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- My code follows the code style of this project.
- If my change requires a change to the documentation I have updated the documentation accordingly.
- I have read the **CONTRIBUTING** document.
- I created an issue for the Pull Request
