### PR TITLE
WIP: Improve global message when multiple files are checked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ typings/
 # Yarn
 yarn.lock
 store/yarn.lock
+
+# IDEs by JetBrains
+.idea

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -14,86 +14,137 @@ const setBuildStatus = ({
   event: currentEvent,
   branch: currentBranch
 }) => {
-  if (fail) build.fail(globalMessage || 'bundle size > maxSize', url)
+  if (fail) build.fail(globalMessage, url)
   else {
     if (currentEvent === 'push' && currentBranch === 'master') {
       const values = []
       files.map(file => values.push({ path: file.path, size: file.size }))
       api.set(values)
     }
-    build.pass(globalMessage || 'Good job! bundle size < maxSize', url)
+    build.pass(globalMessage, url)
   }
-
-  debug('global message', globalMessage)
 }
 
 const compare = (files, masterValues = {}) => {
-  let fail = false
-  let globalMessage
+  let failures = 0
+  let totalSize = 0
+  let totalSizeMaster = 0
+  let totalMaxSize = 0
 
-  files.map(file => {
-    file.master = masterValues[file.path]
-    const { path, size, master, maxSize } = file
+  const results = files.map(file => {
+    const { path, size, maxSize } = file
+    const master = masterValues[path]
 
-    let message = `${path}: ${bytes(size)} `
-    const prettySize = bytes(maxSize)
-    /*
-      if size > maxSize, fail
-      else if size > master, warn + pass
-      else yay + pass
-    */
+    const fail = size > maxSize
+    const change = size - (master || size)
 
-    if (size > maxSize) {
-      fail = true
-      if (prettySize) message += `> maxSize ${prettySize} gzip`
+    totalSize += size
+    totalSizeMaster += master
+    totalMaxSize += maxSize
+
+    let message
+    const prettySize = bytes(size)
+    const prettyMaxSize = bytes(maxSize)
+    const prettyChange =
+      change === 0
+        ? 'no change'
+        : change > 0 ? `+${bytes(change)}` : `-${bytes(Math.abs(change))}`
+
+    if (fail) {
+      failures++
+      message = `${path} is too big: ${prettySize}/${prettyMaxSize} gzip (${prettyChange})`
       error(message, { fail: false, label: 'FAIL' })
-    } else if (!master) {
-      if (prettySize) message += `< maxSize ${prettySize} gzip`
-      info('PASS', message)
     } else {
-      if (prettySize) message += `< maxSize ${prettySize} gzip `
-      const diff = size - master
-
-      if (diff < 0) {
-        message += `(${bytes(Math.abs(diff))} smaller than master, good job!)`
-        info('PASS', message)
-      } else if (diff > 0) {
-        message += `(${bytes(diff)} larger than master, careful!)`
-        warn(message)
-      } else {
-        message += '(same as master)'
-        info('PASS', message)
-      }
+      message = `${path} is: ${prettySize}/${prettyMaxSize} gzip (${prettyChange})`
+      change > 0
+        ? warn(message, { fail: false, label: 'PASS' })
+        : info('PASS', message)
     }
 
-    if (files.length === 1) globalMessage = message
-    return debug('message', message)
+    return {
+      ...file,
+      fail,
+      change,
+      message
+    }
   })
+
+  let globalMessage
+
+  if (results.length === 1) {
+    const { message } = results[0]
+    globalMessage = message
+  } else {
+    if (failures === 1) {
+      // multiple files, one failure
+      const result = results.find(result => result.fail)
+      const { message } = result
+
+      globalMessage = message
+    } else if (failures) {
+      // multiple files, multiple failures
+      const change = totalSize - (totalSizeMaster || totalSize)
+      const prettyChange =
+        change === 0
+          ? 'no change'
+          : change > 0 ? `+${bytes(change)}` : `-${bytes(Math.abs(change))}`
+
+      globalMessage = `${failures} out of ${results.length} bundles are too big! (${prettyChange})`
+    } else {
+      // multiple files, no failures
+      const prettySize = bytes(totalSize)
+      const prettyMaxSize = bytes(totalMaxSize)
+      const change = totalSize - (totalSizeMaster || totalSize)
+      const prettyChange =
+        change === 0
+          ? 'no change'
+          : change > 0 ? `+${bytes(change)}` : `-${bytes(Math.abs(change))}`
+
+      globalMessage = `Total bundle size is ${prettySize}/${prettyMaxSize} gzip (${prettyChange})`
+    }
+  }
+
+  debug('globalMessage', globalMessage)
 
   /* prepare the build page */
   const params = encodeURIComponent(
-    JSON.stringify({ files, repo, branch, commit_message, sha })
+    JSON.stringify({ files: results, repo, branch, commit_message, sha })
   )
   let url = `https://bundlesize-store.now.sh/build?info=${params}`
 
   debug('url before shortening', url)
 
-  shortener
+  return shortener
     .shorten(url)
     .then(res => {
       url = res.data.id
       debug('url after shortening', url)
-      setBuildStatus({ url, files, globalMessage, fail, event, branch })
+      setBuildStatus({
+        url,
+        files: results,
+        globalMessage,
+        fail: !!failures,
+        event,
+        branch
+      })
     })
     .catch(err => {
       debug('err while shortening', err)
-      setBuildStatus({ url, files, globalMessage, fail, event, branch })
+      setBuildStatus({
+        url,
+        files: results,
+        globalMessage,
+        fail: !!failures,
+        event,
+        branch
+      })
     })
 }
 
 const reporter = files => {
-  if (api.enabled) api.get().then(masterValues => compare(files, masterValues))
-  else compare(files)
+  return api.enabled
+    ? api.get().then(masterValues => compare(files, masterValues))
+    : compare(files)
 }
 
 module.exports = reporter

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -108,14 +108,18 @@ const compare = (files, masterValues = {}) => {
   debug('globalMessage', globalMessage)
 
   /* prepare the build page */
+  const buildFiles = Object.assign({}, results)
+  delete buildFiles.fail
+  delete buildFiles.change
+  delete buildFiles.message
   const params = encodeURIComponent(
-    JSON.stringify({ files: results, repo, branch, commit_message, sha })
+    JSON.stringify({ files: buildFiles, repo, branch, commit_message, sha })
   )
   let url = `https://bundlesize-store.now.sh/build?info=${params}`
 
   debug('url before shortening', url)
 
-  return shortener
+  shortener
     .shorten(url)
     .then(res => {
       url = res.data.id
@@ -143,9 +147,8 @@ const compare = (files, masterValues = {}) => {
 }
 
 const reporter = files => {
-  return api.enabled
-    ? api.get().then(masterValues => compare(files, masterValues))
-    : compare(files)
+  if (api.enabled) api.get().then(masterValues => compare(files, masterValues))
+  else compare(files)
 }
 
 module.exports = reporter

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -33,10 +33,10 @@ const compare = (files, masterValues = {}) => {
 
   const results = files.map(file => {
     const { path, size, maxSize } = file
-    const master = masterValues[path]
+    const master = masterValues[path] || size
 
     const fail = size > maxSize
-    const change = size - (master || size)
+    const change = size - master
 
     totalSize += size
     totalSizeMaster += master
@@ -65,7 +65,8 @@ const compare = (files, masterValues = {}) => {
       ...file,
       fail,
       change,
-      message
+      message,
+      master
     }
   })
 
@@ -83,7 +84,7 @@ const compare = (files, masterValues = {}) => {
       globalMessage = message
     } else if (failures) {
       // multiple files, multiple failures
-      const change = totalSize - (totalSizeMaster || totalSize)
+      const change = totalSize - totalSizeMaster
       const prettyChange =
         change === 0
           ? 'no change'
@@ -94,7 +95,7 @@ const compare = (files, masterValues = {}) => {
       // multiple files, no failures
       const prettySize = bytes(totalSize)
       const prettyMaxSize = bytes(totalMaxSize)
-      const change = totalSize - (totalSizeMaster || totalSize)
+      const change = totalSize - totalSizeMaster
       const prettyChange =
         change === 0
           ? 'no change'


### PR DESCRIPTION
This is a pull request for issue #182

## Description
This is a work in progress. Although the status message works correctly, I broke two features that I need help with to fix:
1. CI does not log messages (like the local log below) anymore
2. The details page does not show the size of master anymore (but change is calculated correctly)

To test this pull request on your own project: `yarn add --dev StephanBijzitter/bundlesize`

## Motivation and Context
Currently, you cannot see the change compared to master in your pull request if you check more than one file. This pull request resolves this by showing different messages based on the results.

## Screenshots (if appropriate):
Local output (doesn't show change, just like now):
```
 FAIL  ./bundlesize/app.js is too big: 46.93KB/5KB gzip (no change) 

 FAIL  ./bundlesize/vendor.js is too big: 287.54KB/10KB gzip (no change) 

 PASS  ./bundlesize/app.css is: 22.59KB/50KB gzip (no change) 

 PASS  ./bundlesize/vendor.css is: 3.13KB/10KB gzip (no change) 

 DEBUG globalMessage: "2 out of 4 bundles are too big! (no change)" 

```
Status message is relayed to the pull request correctly:
![image](https://user-images.githubusercontent.com/1649903/32654396-6525ae7a-c60b-11e7-9d15-fea41f994b21.png)

## Types of changes
- New feature (non-breaking change which adds functionality)

## TODO
1. CI does not log messages (like the local log below) anymore
2. The details page does not show the size of master anymore (but change is calculated correctly)
3. Clean up duplication in code

