### PR TITLE
chore: remove sponsor from image

### DIFF
--- a/store/views/build.pug
+++ b/store/views/build.pug
@@ -33,12 +33,6 @@
               <div class="master light"><span class="mobile">master</span> #{file.diff}</div>
           </div>
       </div>
-      <div class="sponsor">
-        <div>server bills paid with the help of our sponsors</div>
-        <div class="sponsor-image">
-          <a href="https://app.codesponsor.io/link/LhLT2c31ydJzdLUuSR9f8mCA/siddharthkp/bundlesize-details" rel="nofollow"><img src="https://app.codesponsor.io/embed/LhLT2c31ydJzdLUuSR9f8mCA/siddharthkp/bundlesize-details.svg" style="width: 888px; height: 68px;" alt="Sponsor" /></a>
-        </div>
-      </div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
Since codeSponsor doesn't exist anymore (see also #192), this image 404s and the page doesn't exist anymore

<!--- Provide a general summary of your changes in the Title above -->

