### PR TITLE
Add minSize option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ Example:
 
 ```
 
+You can check for minimum size too.
+
+Example:
+
+```json
+"bundlesize": [
+  {
+    "path": "./dist.js",
+    "maxSize": "3 kB"
+    "minSize": "2 kB"
+  }
+]
+
+```
+
 This makes it great for using with applications that are bundled with another tool. It will match multiple files if necessary and create a new row for each file.
 
 &nbsp;
@@ -105,6 +120,7 @@ example usage:
 
 ```sh
 bundlesize -f "dist/*.js" -s 20kB
+bundlesize -f "dist/*.js" -s 20kB --min-size 15kB
 ```
 
 For more granular configuration, we recommend configuring it in the `package.json` (documented above).

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
   },
   "scripts": {
     "precommit": "lint-staged",
-    "test": "npm run test:default && npm run test:no-compression && npm run test:brotli-compression",
+    "test": "npm run test:default && npm run test:min-size && npm run test:no-compression && npm run test:brotli-compression",
     "test:default": "node index && cat pipe.js | node pipe --name pipe.js --max-size 1kB",
+    "test:min-size": "node index && cat pipe.js | node pipe --name pipe.js --max-size 1kB --min-size 0.5kB",
     "test:no-compression": "cat pipe.js | node pipe --compression none --name pipe.js",
     "test:brotli-compression": "cat pipe.js | node pipe --compression brotli --name pipe.js",
     "lint": "eslint src store/*.js"
@@ -52,7 +53,8 @@
   "bundlesize": [
     {
       "path": "./index.js",
-      "maxSize": "600B"
+      "maxSize": "600B",
+      "minSize": "100B"
     },
     {
       "path": "./src/files.js",
@@ -61,6 +63,7 @@
     {
       "path": "./src/compressed-size.js",
       "maxSize": "420B",
+      "minSize": "200B",
       "compression": "none"
     }
   ],

--- a/pipe.js
+++ b/pipe.js
@@ -17,6 +17,7 @@ if (process.stdin.isTTY) {
 program
   .option('-n, --name [name]', 'custom name for a file (lib.min.js)')
   .option('-s, --max-size [maxSize]', 'maximum size threshold (3Kb)')
+  .option('--min-size [minSize]', 'minimum size threshold (2Kb)')
   .option(
     '-c, --compression [gzip|brotli|none]',
     'specify which compression algorithm to use'
@@ -27,6 +28,7 @@ program
 const config = {
   name: program.name || require('read-pkg-up').sync().pkg.name,
   maxSize: program.maxSize,
+  minSize: program.minSize,
   compression: program.compression || 'gzip'
 }
 
@@ -36,9 +38,11 @@ process.stdin.setEncoding('utf8')
 readStream(process.stdin).then(data => {
   const size = compressedSize(data, config.compression)
   const maxSize = bytes(config.maxSize) || Infinity
+  const minSize = bytes(config.minSize) || 0
   const file = {
     path: config.name,
     maxSize,
+    minSize,
     size,
     compression: config.compression
   }

--- a/src/config.js
+++ b/src/config.js
@@ -13,6 +13,7 @@ const packageJSONconfig = pkg.bundlesize
 program
   .option('-f, --files [files]', 'files to test against (dist/*.js)')
   .option('-s, --max-size [maxSize]', 'maximum size threshold (3Kb)')
+  .option('--min-size [minSize]', 'minimum size threshold (2Kb)')
   .option('--debug', 'run in debug mode')
   .option(
     '-c, --compression [compression]',
@@ -21,12 +22,12 @@ program
   .parse(process.argv)
 
 let cliConfig
-
 if (program.files) {
   cliConfig = [
     {
       path: program.files,
       maxSize: program.maxSize,
+      minSize: program.minSize,
       compression: program.compression || 'gzip'
     }
   ]

--- a/src/files.js
+++ b/src/files.js
@@ -16,9 +16,10 @@ config.map(file => {
   } else {
     paths.map(path => {
       const maxSize = bytes(file.maxSize) || Infinity
+      const minSize = bytes(file.minSize) || 0
       const compression = file.compression || 'gzip'
       const size = compressedSize(fs.readFileSync(path, 'utf8'), compression)
-      files.push({ maxSize, path, size, compression })
+      files.push({ maxSize, minSize, path, size, compression })
     })
   }
 })


### PR DESCRIPTION
Adds `minSize`, `--min-size` option to fail if size of the bundle is too small.

## Description

<!--- Describe your changes  -->

## Motivation and Context
Fixes #207.
Sometimes it's useful to also have a warning when your bundle suddenly becomes too small, maybe that wasn't intentional.
This crosses a bit into the functional tests realm but this check I think is simple enough and could serve as a sanity check for some hard-to-test changes, like in css bundles, which require visual/screenshot testing that is not always done.

Even if functional tests for your build are implemented I think the name `bundlesize` and `maxSize` options do imply that this tool made for the checking all the things about allowed sizes of files, so it makes sense to keep the information about minimal allowed sizes in the same config.

## Screenshots (if appropriate):
![screenshot_2018-04-04_12-38-09](https://user-images.githubusercontent.com/174250/38290359-22671bb6-3805-11e8-83f4-76b4bcdd13ac.png)

## Types of changes

<!--- Leave the one fitting to your PR  -->

- New feature (non-breaking change which adds functionality)