### PR TITLE
Support Configurable Settings File

### DIFF
--- a/.bundlesizeconfig
+++ b/.bundlesizeconfig
@@ -1,0 +1,8 @@
+{
+  "bundlesize": [
+    {
+      "path": "./index.js",
+      "maxSize": "1000B"
+    }
+  ]
+}

--- a/.bundlesizeconfig
+++ b/.bundlesizeconfig
@@ -1,5 +1,5 @@
 {
-  "bundlesize": [
+  "files": [
     {
       "path": "./index.js",
       "maxSize": "1000B"

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ By default the gzipped size is tested. You can use the `compression` option to c
 ##### external config file `.bundlesizeconfig`
 ```json
 {
-  "bundlesize": [
+  "files": [
     {
       "path": "./index.js",
       "maxSize": "1000B"

--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ npx bundlesize
 
 &nbsp;
 
-#### 1) Add the path and maxSize in your `package.json`.
+#### 1) Add the path and maxSize in your `package.json` or a defined config file.
 By default the gzipped size is tested. You can use the `compression` option to change this. (`gzip`, `brotli`, or `none`).
 
+##### within `package.json`
 ```json
 {
   "name": "your cool library",
@@ -62,6 +63,27 @@ By default the gzipped size is tested. You can use the `compression` option to c
   ]
 }
 ```
+
+##### external config file `.bundlesizeconfig`
+```json
+{
+  "bundlesize": [
+    {
+      "path": "./index.js",
+      "maxSize": "1000B"
+    }
+  ]
+}
+```
+and then your package scripts:
+```json
+"scripts": {
+  "test": "bundlesize --config ./.bundlesizeconfig"
+}
+```
+
+&nbsp;
+
 
 `bundlesize` also supports [glob patterns](https://github.com/isaacs/node-glob)
 

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
   },
   "scripts": {
     "precommit": "lint-staged",
-    "test": "npm run test:default && npm run test:no-compression && npm run test:brotli-compression",
+    "test": "npm run test:default && npm run test:no-compression && npm run test:brotli-compression && npm run test:config-file",
     "test:default": "node index && cat pipe.js | node pipe --name pipe.js --max-size 1kB",
     "test:no-compression": "cat pipe.js | node pipe --compression none --name pipe.js",
     "test:brotli-compression": "cat pipe.js | node pipe --compression brotli --name pipe.js",
+    "test:config-file": "cat pipe.js | node pipe --config ./.bundlesizeconfig",
     "lint": "eslint src store/*.js"
   },
   "keywords": [

--- a/pipe.js
+++ b/pipe.js
@@ -36,7 +36,7 @@ const configBase = {
 }
 
 const bundlesizeConfigFile = program.config
-  ? JSON.parse(fs.readFileSync(program.config, 'utf8')).bundlesize[0]
+  ? JSON.parse(fs.readFileSync(program.config, 'utf8')).files[0]
   : false
 
 const config = bundlesizeConfigFile

--- a/pipe.js
+++ b/pipe.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 const { inspect } = require('util')
 const program = require('commander')
+const fs = require('fs')
 const reporter = require('./src/reporter')
 
 const bytes = require('bytes')
@@ -16,6 +17,10 @@ if (process.stdin.isTTY) {
 
 program
   .option('-n, --name [name]', 'custom name for a file (lib.min.js)')
+  .option(
+    '-n, --config [config]',
+    'set external config (ex: ./.bundlesizeconfig)'
+  )
   .option('-s, --max-size [maxSize]', 'maximum size threshold (3Kb)')
   .option(
     '-c, --compression [gzip|brotli|none]',
@@ -24,11 +29,19 @@ program
   .option('--debug', 'run in debug mode')
   .parse(process.argv)
 
-const config = {
+const configBase = {
   name: program.name || require('read-pkg-up').sync().pkg.name,
   maxSize: program.maxSize,
   compression: program.compression || 'gzip'
 }
+
+const bundlesizeConfigFile = program.config
+  ? JSON.parse(fs.readFileSync(program.config, 'utf8')).bundlesize[0]
+  : false
+
+const config = !bundlesizeConfigFile
+  ? { ...configBase }
+  : { ...configBase, name: bundlesizeConfigFile.path }
 
 debug('config', config)
 

--- a/pipe.js
+++ b/pipe.js
@@ -39,9 +39,9 @@ const bundlesizeConfigFile = program.config
   ? JSON.parse(fs.readFileSync(program.config, 'utf8')).bundlesize[0]
   : false
 
-const config = !bundlesizeConfigFile
-  ? { ...configBase }
-  : { ...configBase, name: bundlesizeConfigFile.path }
+const config = bundlesizeConfigFile
+  ? { ...configBase, name: bundlesizeConfigFile.path }
+  : { ...configBase }
 
 debug('config', config)
 

--- a/src/config.js
+++ b/src/config.js
@@ -9,7 +9,10 @@ const debug = require('./debug')
 /* Config from CLI */
 program
   .option('-f, --files [files]', 'files to test against (dist/*.js)')
-  .option('-n, --config [config]', 'set external config (bundlesize.json)')
+  .option(
+    '-n, --config [config]',
+    'set external config (ex: ./.bundlesizeconfig)'
+  )
   .option('-s, --max-size [maxSize]', 'maximum size threshold (3Kb)')
   .option('--debug', 'run in debug mode')
   .option(
@@ -31,14 +34,11 @@ if (program.files) {
   ]
 }
 
-/* Config from package.json or bundlesize.json */
-let jsonConfig
-if (program.config && fs.existsSync('./bundlesize.json')) {
-  const cnfg = JSON.parse(fs.readFileSync('bundlesize.json', 'utf8'))
-  jsonConfig = cnfg.bundlesize
-} else {
-  jsonConfig = pkg.bundlesize
-}
+/* Config from package.json or config */
+const jsonConfig =
+  program.config && fs.existsSync(program.config)
+    ? JSON.parse(fs.readFileSync(program.config, 'utf8')).bundlesize
+    : pkg.bundlesize
 
 /* Send to readme if no configuration is provided */
 if (!jsonConfig && !cliConfig) {

--- a/src/config.js
+++ b/src/config.js
@@ -37,7 +37,7 @@ if (program.files) {
 /* Config from package.json or config */
 const jsonConfig =
   program.config && fs.existsSync(program.config)
-    ? JSON.parse(fs.readFileSync(program.config, 'utf8')).bundlesize
+    ? JSON.parse(fs.readFileSync(program.config, 'utf8')).files
     : pkg.bundlesize
 
 /* Send to readme if no configuration is provided */


### PR DESCRIPTION
## Description

When --config is passed in cli and there is a valid bundlesize.json file present in the project, then the bundlesize settings will be pulled from this file, and not from package.json


## Motivation and Context

In a project with a lot of code chunks that are all validated with this bundlesize checker tool, it bloats the package.json. Wanted an external config to bring all that into a common area. Didnt expand too much into things like yaml file or anything overly complex, just a good place to start for the people who need smaller package.json files 😄 


## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

- My code follows the code style of this project. ✅
- If my change requires a change to the documentation I have updated the documentation accordingly. ✅
      - Updated first step in README
- I have read the **CONTRIBUTING** document. ✅
- I created an issue for the Pull Request ✅
      - https://github.com/siddharthkp/bundlesize/issues/206 
      - https://github.com/siddharthkp/bundlesize/issues/162
      - https://github.com/siddharthkp/bundlesize/issues/173
