### PR TITLE
Make Brotli and optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.17.0",
-    "brotli-size": "0.0.1",
     "bytes": "^3.0.0",
     "ci-env": "^1.4.0",
     "commander": "^2.11.0",
@@ -48,6 +47,9 @@
     "gzip-size": "^4.0.0",
     "prettycli": "^1.4.3",
     "read-pkg-up": "^3.0.0"
+  },
+  "optionalDependencies": {
+    "brotli-size": "0.0.1"
   },
   "bundlesize": [
     {

--- a/src/compressed-size.js
+++ b/src/compressed-size.js
@@ -1,5 +1,4 @@
 const gzip = require('gzip-size')
-const brotli = require('brotli-size')
 
 const getCompressedSize = (data, compression = 'gzip') => {
   let size
@@ -8,7 +7,12 @@ const getCompressedSize = (data, compression = 'gzip') => {
       size = gzip.sync(data)
       break
     case 'brotli':
-      size = brotli.sync(data)
+      try {
+        const brotli = require('brotli-size')
+        size = brotli.sync(data)
+      } catch (e) {
+        console.warn('Missing optional dependency: brotli-size')
+      }
       break
     case 'none':
     default:


### PR DESCRIPTION
## Description

1. Move `"brotli-size": "0.0.1"` from `dependencies` to `optionalDependencies`
2. Put a try-catch around `require('brotli-size')` and move it inside `case 'brotli':`
    - in the catch, `console.warn('Missing optional dependency: brotli-size')`

## Motivation and Context

It turns out the `brotli-size` (#194) is quite big and doesn't install very nicely on Windows. See the following issues:

Fixes #202
Fixes #213
