### PR TITLE
Make brotli-size optional by styfle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_script:
   - greenkeeper-lockfile-update
 script:
   - npm run lint
+  - npm test
 after_script: greenkeeper-lockfile-upload
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ npx bundlesize
 #### 1) Add the path and maxSize in your `package.json`.
 By default the gzipped size is tested. You can use the `compression` option to change this. (`gzip`, `brotli`, or `none`).
 
+To use the `brotli` compression option, you must install the peer dependency: `npm install --save brotli-size`
+
 ```json
 {
   "name": "your cool library",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "read-pkg-up": "^3.0.0"
   },
   "optionalDependencies": {
-    "brotli-size": "0.0.1"
+    "brotli-size": "0.0.2"
   },
   "bundlesize": [
     {

--- a/package.json
+++ b/package.json
@@ -48,9 +48,6 @@
     "prettycli": "^1.4.3",
     "read-pkg-up": "^3.0.0"
   },
-  "peerDependencies": {
-    "brotli-size": ">=0.0.1"
-  },
   "bundlesize": [
     {
       "path": "./index.js",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "prettycli": "^1.4.3",
     "read-pkg-up": "^3.0.0"
   },
-  "optionalDependencies": {
-    "brotli-size": "0.0.2"
+  "peerDependencies": {
+    "brotli-size": ">=0.0.1"
   },
   "bundlesize": [
     {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.17.0",
-    "brotli-size": "0.0.1",
     "bytes": "^3.0.0",
     "ci-env": "^1.4.0",
     "commander": "^2.11.0",
@@ -48,6 +47,9 @@
     "gzip-size": "^4.0.0",
     "prettycli": "^1.4.3",
     "read-pkg-up": "^3.0.0"
+  },
+  "optionalDependencies": {
+    "brotli-size": "0.0.1"
   },
   "bundlesize": [
     {

--- a/src/compressed-size.js
+++ b/src/compressed-size.js
@@ -1,5 +1,4 @@
 const gzip = require('gzip-size')
-const brotli = require('brotli-size')
 
 const getCompressedSize = (data, compression = 'gzip') => {
   let size
@@ -8,7 +7,12 @@ const getCompressedSize = (data, compression = 'gzip') => {
       size = gzip.sync(data)
       break
     case 'brotli':
-      size = brotli.sync(data)
+      try {
+        const brotli = require('brotli-size')
+        size = brotli.sync(data)
+      } catch (e) {
+        console.warn('Missing optional dependency: brotli-size')
+      }
       break
     case 'none':
     default:

--- a/src/compressed-size.js
+++ b/src/compressed-size.js
@@ -1,3 +1,4 @@
+const { warn } = require('prettycli')
 const gzip = require('gzip-size')
 
 const getCompressedSize = (data, compression = 'gzip') => {
@@ -11,7 +12,8 @@ const getCompressedSize = (data, compression = 'gzip') => {
         const brotli = require('brotli-size')
         size = brotli.sync(data)
       } catch (e) {
-        console.warn('Missing optional dependency: brotli-size')
+        warn(`Missing optional dependency. Install it with:
+          npm install --save brotli-size`)
       }
       break
     case 'none':

--- a/src/compressed-size.js
+++ b/src/compressed-size.js
@@ -1,5 +1,6 @@
 const { warn } = require('prettycli')
 const gzip = require('gzip-size')
+let brotli
 
 const getCompressedSize = (data, compression = 'gzip') => {
   let size
@@ -9,12 +10,12 @@ const getCompressedSize = (data, compression = 'gzip') => {
       break
     case 'brotli':
       try {
-        const brotli = require('brotli-size')
-        size = brotli.sync(data)
+        brotli = require('brotli-size')
       } catch (e) {
         warn(`Missing optional dependency. Install it with:
           npm install --save brotli-size`)
       }
+      size = brotli ? brotli.sync(data) : 0
       break
     case 'none':
     default:

--- a/src/compressed-size.js
+++ b/src/compressed-size.js
@@ -1,4 +1,3 @@
-const { warn } = require('prettycli')
 const gzip = require('gzip-size')
 let brotli
 

--- a/src/compressed-size.js
+++ b/src/compressed-size.js
@@ -12,10 +12,10 @@ const getCompressedSize = (data, compression = 'gzip') => {
       try {
         brotli = require('brotli-size')
       } catch (e) {
-        warn(`Missing optional dependency. Install it with:
+        throw new Error(`Missing optional dependency. Install it with:
           npm install --save brotli-size`)
       }
-      size = brotli ? brotli.sync(data) : 0
+      size = brotli.sync(data)
       break
     case 'none':
     default:


### PR DESCRIPTION
## Description

1. Remove `brotli-size` from `dependencies`
2. Add try-catch around `require('brotli-size')`
3. Warn if using brotli option but missing `brotli-size`

## Motivation and Context

It turns out the `brotli-size` (#194) is quite big and doesn't install very nicely on Windows.

See the following issues:

Fixes #202
Fixes #213
