### PR TITLE
Exit script with error even if token is provided

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -4,9 +4,10 @@ const { repo, sha } = require('ci-env')
 const token = require('./token')
 const debug = require('./debug')
 
+const exit = () => process.exit(1)
 let pass = () => {} // noop
-let fail = () => process.exit(1)
-let error = () => process.exit(1)
+let fail = exit
+let error = exit
 
 const label = 'bundlesize'
 const description = 'Checking output size...'
@@ -28,8 +29,16 @@ if (token) {
 
   build.start().catch(handleError)
   pass = (message, url) => build.pass(message, url).catch(handleError)
-  fail = (message, url) => build.fail(message, url).catch(handleError)
-  error = (message, url) => build.error(message, url).catch(handleError)
+  fail = (message, url) =>
+    build
+      .fail(message, url)
+      .catch(handleError)
+      .then(exit)
+  error = (message, url) =>
+    build
+      .error(message, url)
+      .catch(handleError)
+      .then(exit)
 }
 
 module.exports = { pass, fail, error }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When `bundlesize` fails a check, exit with status code of `1`.

## Motivation and Context
In certain CIs, the exit status is used to indicate whether the build succeeded or failed. Currently, if a CI token is provided, the build exits with `0` status code hence some CI will mark the build as successful.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to change)
Previously passing builds in CIs will now fail if `bundlesize` check fails.

## Checklist:
- My code follows the code style of this project. ✅ 
- If my change requires a change to the documentation I have updated the documentation accordingly. ✅ 
- I have read the **CONTRIBUTING** document. ✅ 
- I created an issue for the Pull Request ✅ 
