### PR TITLE
Add Open-Mode to extends the possibilities of usages

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
 const { inspect } = require('util')
-const files = require('./src/files')
+const { files, enabledOpenMode } = require('./src/files')
 const reporter = require('./src/reporter')
 const build = require('./src/build')
 
-reporter(files)
+reporter(files, enabledOpenMode)
 
 process.on('unhandledRejection', function(reason) {
   console.log('Unhandled Promise')

--- a/src/config.js
+++ b/src/config.js
@@ -12,12 +12,10 @@ const packageJSONconfig = pkg.bundlesize
 
 program
   .option('-f, --files [files]', 'files to test against (dist/*.js)')
+  .option('-o, --open', 'Allow to run in open mode')
   .option('-s, --max-size [maxSize]', 'maximum size threshold (3Kb)')
   .option('--debug', 'run in debug mode')
-  .option(
-    '-c, --compression [compression]',
-    'specify which compression algorithm to use'
-  )
+  .option('-c, --compression [compression]', 'specify which compression algorithm to use')
   .parse(process.argv)
 
 let cliConfig
@@ -27,7 +25,8 @@ if (program.files) {
     {
       path: program.files,
       maxSize: program.maxSize,
-      compression: program.compression || 'gzip'
+      compression: program.compression || 'gzip',
+      ...(program.open && { openMode: true })
     }
   ]
 }

--- a/src/files.js
+++ b/src/files.js
@@ -6,6 +6,7 @@ const config = require('./config')
 const debug = require('./debug')
 const compressedSize = require('./compressed-size')
 const files = []
+let enabledOpenMode = false
 
 config.map(file => {
   const paths = glob.sync(file.path)
@@ -18,6 +19,7 @@ config.map(file => {
       const maxSize = bytes(file.maxSize) || Infinity
       const compression = file.compression || 'gzip'
       const size = compressedSize(fs.readFileSync(path, 'utf8'), compression)
+      enabledOpenMode = !!file.openMode
       files.push({ maxSize, path, size, compression })
     })
   }
@@ -25,4 +27,4 @@ config.map(file => {
 
 debug('files', files)
 
-module.exports = files
+module.exports = { files, enabledOpenMode }

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -163,8 +163,11 @@ const compare = (files, masterValues = {}) => {
   report({ files, globalMessage, fail })
 }
 
-const reporter = files => {
+const getTotalSize = files => console.log(files.reduce((acc, file) => acc + file.size, 0))
+
+const reporter = (files, enabledOpenMode) => {
   if (api.enabled) api.get().then(masterValues => compare(files, masterValues))
+  else if (enabledOpenMode) getTotalSize(files)
   else compare(files)
 }
 


### PR DESCRIPTION
## Description

The `Open-Mode` has the goal to extends the possibilities by using only the crucial information of the size of the build and nothing else, thus it permits to use this data to create a lot of other things and not only for a CI purpose in case of fail or success depending a maxsize.

## Motivation and Context

Issue #253.

<!--- Why is this change required? What problem does it solve? -->
It extends the possibilities of usage of `bundlesize` by having only the crucial information of the build size. 

## Types of changes

<!--- Leave the one fitting to your PR  -->

- Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points and make sure you have done all of those -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I created an issue for the Pull Request

Concerning the style of the project, a bug occur linked to prettier, I've created an Pull request that is related to #246 

For the documentation, this feature is not certain to be accepted yet, so I will update the doc when we will be sure.

Thank's :)