### PR TITLE
Add consistency between prettier and eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,5 +9,6 @@ module.exports = {
         semi: false,
       },
     ],
+    'comma-dangle': ["error", "always-multiline"],
   },
 };

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  trailingComma: 'es5',
+  tabWidth: 2,
+  semi: false,
+  singleQuote: true,
+}

--- a/src/api.js
+++ b/src/api.js
@@ -46,9 +46,7 @@ const set = values => {
     repo = repo.replace(/\./g, '_')
     debug('saving values')
 
-    axios
-      .post(url, { repo, token, sha, values })
-      .catch(error => console.log(error))
+    axios.post(url, { repo, token, sha, values }).catch(error => console.log(error))
   }
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -14,10 +14,7 @@ program
   .option('-f, --files [files]', 'files to test against (dist/*.js)')
   .option('-s, --max-size [maxSize]', 'maximum size threshold (3Kb)')
   .option('--debug', 'run in debug mode')
-  .option(
-    '-c, --compression [compression]',
-    'specify which compression algorithm to use'
-  )
+  .option('-c, --compression [compression]', 'specify which compression algorithm to use')
   .parse(process.argv)
 
 let cliConfig
@@ -27,8 +24,8 @@ if (program.files) {
     {
       path: program.files,
       maxSize: program.maxSize,
-      compression: program.compression || 'gzip'
-    }
+      compression: program.compression || 'gzip',
+    },
   ]
 }
 

--- a/src/files.js
+++ b/src/files.js
@@ -11,7 +11,7 @@ config.map(file => {
   const paths = glob.sync(file.path)
   if (!paths.length) {
     error(`There is no matching file for ${file.path} in ${process.cwd()}`, {
-      silent: true
+      silent: true,
     })
   } else {
     paths.map(path => {

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,6 +1,6 @@
 const bytes = require('bytes')
 const { error, warn, info } = require('prettycli')
-const { event, repo, branch, commit_message, sha } = require('ci-env')
+const { event, repo, branch, commit_message, sha } = require('ci-env') //eslint-disable-line
 const build = require('./build')
 const api = require('./api')
 const debug = require('./debug')
@@ -12,7 +12,7 @@ const setBuildStatus = ({
   globalMessage,
   fail,
   event: currentEvent,
-  branch: currentBranch
+  branch: currentBranch,
 }) => {
   if (fail) build.fail(globalMessage || 'bundle size > maxSize', url)
   else {
@@ -28,12 +28,7 @@ const setBuildStatus = ({
 }
 
 // Generate global message as per https://github.com/siddharthkp/bundlesize/issues/182#issuecomment-343274689
-const getGlobalMessage = ({
-  results,
-  totalSize,
-  totalSizeMaster,
-  totalMaxSize
-}) => {
+const getGlobalMessage = ({ results, totalSize, totalSizeMaster, totalMaxSize }) => {
   let globalMessage
 
   let failures = results.filter(result => !!result.fail).length
@@ -51,9 +46,7 @@ const getGlobalMessage = ({
     // multiple files, multiple failures
     const change = totalSize - totalSizeMaster
     const prettyChange =
-      change === 0
-        ? 'no change'
-        : change > 0 ? `+${bytes(change)}` : `-${bytes(Math.abs(change))}`
+      change === 0 ? 'no change' : change > 0 ? `+${bytes(change)}` : `-${bytes(Math.abs(change))}`
 
     globalMessage = `${failures} out of ${results.length} bundles are too big! (${prettyChange})`
   } else {
@@ -62,9 +55,7 @@ const getGlobalMessage = ({
     const prettyMaxSize = bytes(totalMaxSize)
     const change = totalSize - totalSizeMaster
     const prettyChange =
-      change === 0
-        ? 'no change'
-        : change > 0 ? `+${bytes(change)}` : `-${bytes(Math.abs(change))}`
+      change === 0 ? 'no change' : change > 0 ? `+${bytes(change)}` : `-${bytes(Math.abs(change))}`
 
     globalMessage = `Total bundle size is ${prettySize}/${prettyMaxSize} (${prettyChange})`
   }
@@ -122,16 +113,14 @@ const analyse = ({ files, masterValues }) => {
       fail,
       size,
       master,
-      maxSize
+      maxSize,
     }
   })
 }
 
 const report = ({ files, globalMessage, fail }) => {
   /* prepare the build page */
-  const params = encodeURIComponent(
-    JSON.stringify({ files, repo, branch, commit_message, sha })
-  )
+  const params = encodeURIComponent(JSON.stringify({ files, repo, branch, commit_message, sha })) //eslint-disable-line
   let url = `https://bundlesize-store.now.sh/build?info=${params}`
 
   debug('url before shortening', url)
@@ -156,7 +145,7 @@ const compare = (files, masterValues = {}) => {
     results,
     totalSize: results.reduce((acc, result) => acc + result.size, 0),
     totalSizeMaster: results.reduce((acc, result) => acc + result.master, 0),
-    totalMaxSize: results.reduce((acc, result) => acc + result.maxSize, 0)
+    totalMaxSize: results.reduce((acc, result) => acc + result.maxSize, 0),
   })
 
   let fail = results.filter(result => result.fail).length > 0

--- a/src/shortener.js
+++ b/src/shortener.js
@@ -8,8 +8,8 @@ const shorten = longUrl =>
     method: 'POST',
     url: `${url}?key=${googleApiKey}`,
     data: {
-      longUrl
-    }
+      longUrl,
+    },
   })
 
 const shortener = { shorten }

--- a/store/github.js
+++ b/store/github.js
@@ -12,8 +12,8 @@ const token = code =>
     data: {
       code,
       client_id: process.env.githubId,
-      client_secret: process.env.githubSecret
-    }
+      client_secret: process.env.githubSecret,
+    },
   })
     .then(response => response.data)
     .catch(response => response.response.status)

--- a/store/migrate.js
+++ b/store/migrate.js
@@ -8,7 +8,7 @@ tokens.map(token => {
     const repos = Object.keys(initial[token][users])
     repos.map(repo => {
       const future = {
-        '-Kp6JuK8QrSeYBh4g_0K': initial[token][users][repo]
+        '-Kp6JuK8QrSeYBh4g_0K': initial[token][users][repo],
       }
       initial[token][users][repo] = future
     })

--- a/store/newrelic.js
+++ b/store/newrelic.js
@@ -5,5 +5,5 @@ if (process.env.dev) {
 exports.config = {
   app_name: ['bundlesize store'],
   license_key: process.env.newrelicKey,
-  logging: { level: 'info' }
+  logging: { level: 'info' },
 }


### PR DESCRIPTION
…lint

<!--- Provide a general summary of your changes in the Title above -->

## Description

I've add a `prettier.config.js` file to be sure that everyone is using the same config to apply prettier on the project.
I also added a `comma-dangle` property on eslint.

We also had a problem on a eslint property concerning the `camelcase`, so I disabled the 2 lines concerned, because it depends on the `ci-env` packages. So, we need to edit it first.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The `yarn lint` script was not working correctly.  
I also wanted to add `comma-dangle` to improve the readability of future pull request.
<!--- If it fixes an open issue, please link to the issue here. -->
This PR is closely related to the issue #246  

## Types of changes

Chore

<!--- Leave the one fitting to your PR  -->

- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points and make sure you have done all of those -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I created an issue for the Pull Request
