### PR TITLE
Fix read file of type gzip

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -17,7 +17,7 @@ config.map(file => {
     paths.map(path => {
       const maxSize = bytes(file.maxSize) || Infinity
       const compression = file.compression || 'gzip'
-      const size = compressedSize(fs.readFileSync(path, 'utf8'), compression)
+      const size = compressedSize(fs.readFileSync(path), compression)
       files.push({ maxSize, path, size, compression })
     })
   }


### PR DESCRIPTION
## Description

When reading gzip files, with `utf8` encoding, files have wrong size

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- My code follows the code style of this project.
- If my change requires a change to the documentation I have updated the documentation accordingly.
- I have read the **CONTRIBUTING** document.
- I created an issue for the Pull Request

#266 
