### PR TITLE
Compress JSON payload used in reporter URL

### DIFF
--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,4 +1,5 @@
 const bytes = require('bytes')
+const zlib = require('zlib')
 const { error, warn, info } = require('prettycli')
 const { event, repo, branch, commit_message, sha } = require('ci-env')
 const build = require('./build')
@@ -129,10 +130,11 @@ const analyse = ({ files, masterValues }) => {
 
 const report = ({ files, globalMessage, fail }) => {
   /* prepare the build page */
-  const params = encodeURIComponent(
-    JSON.stringify({ files, repo, branch, commit_message, sha })
+  const params = JSON.stringify({ files, repo, branch, commit_message, sha })
+  const compressedData = encodeURIComponent(
+    zlib.gzipSync(params).toString('base64')
   )
-  let url = `https://bundlesize-store.now.sh/build?info=${params}`
+  let url = `https://bundlesize-store.now.sh/build?data=${compressedData}`
 
   debug('url before shortening', url)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This gzips and base64 encodes the JSON for huge compression gains (raw URI encoded JSON was 8539 characters, gzipped and base64 was 950). Backwards compatibility is maintained by using a new query parameter (`data` instead of `info`) and only using the new one if the old one is not present.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Because all data is passed to the reporter as JSON, it can get very big due to the number of characters which need to be escaped. 

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/siddharthkp/bundlesize/issues/275

## Screenshots (if appropriate):

## Types of changes

<!--- Leave the one fitting to your PR  -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points and make sure you have done all of those -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- My code follows the code style of this project.
- If my change requires a change to the documentation I have updated the documentation accordingly.
- I have read the **CONTRIBUTING** document.
- I created an issue for the Pull Request
