### PR TITLE
fix: build should return noop on non-ci environments

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -1,6 +1,6 @@
 const Build = require('github-build')
 const prettycli = require('prettycli')
-const { repo, sha } = require('ci-env')
+const { repo, sha, ci } = require('ci-env')
 const token = require('./token')
 const debug = require('./debug')
 
@@ -18,7 +18,7 @@ debug('token exists', !!token)
 debug('repo', repo)
 debug('sha', sha)
 
-if (token) {
+if (ci && token) {
   const handleError = err => {
     const message = `Could not add github status.
         ${err.status}: ${err.error.message}`


### PR DESCRIPTION
## Description

+ On non ci envrionements like running on local machine, bundlesize should not try to update non existing Github builds even though the token env is set. 

## Motivation and Context

+ export BUNDLESIZE_GITHUB_TOKEN="blah"
+ `npm run bundlesize`

```js
 ERROR  Could not add github status.
      404: Not Found
```

## Types of changes
- Bug fix (non-breaking change which fixes an issue)
