### PR TITLE
fix(store): better display for long path names

### DIFF
--- a/store/static/styles.css
+++ b/store/static/styles.css
@@ -44,19 +44,17 @@ body {
   display: inline-block;
   word-wrap: break-word;
 }
-.path {
-  width: 20%;
-}
-.threshold {
-  width: 50%;
+.size-wrapper {
+  display: flex;
+  justify-content: flex-end;
 }
 .size {
   text-align: right;
-  width: 15%;
+  margin: 0 .2em;
 }
 .master {
   text-align: right;
-  width: 10%;
+  margin: 0 .2em;
 }
 .bar {
   height: 7px;

--- a/store/views/build.pug
+++ b/store/views/build.pug
@@ -18,8 +18,10 @@
         <div class="labels desktop">
           <div class="light label path">PATH</div>
           <div class="light label threshold"></div>
-          <div class="light label size">SIZE/THRESHOLD</div>
-          <div class="light label master">MASTER</div>
+          <div class="size-wrapper">
+            <div class="light label size">SIZE/THRESHOLD</div>
+            <div class="light label master">MASTER</div>
+          </div>
         </div>
         each file in files
           <div class="file">
@@ -28,9 +30,11 @@
               <div class="bar first" style="width: #{file.fillLength * 100 / file.length}%"></div>
               <div class="bar length" style="background-color: #{file.baseColor}"></div>
             </div>
-            <div class="size light">#{file.prettySize}/#{file.prettyMaxSize}#{file.unit}</div>
-            if file.diff
-              <div class="master light"><span class="mobile">master</span> #{file.diff}</div>
+            <div class="size-wrapper">
+              <div class="size light">#{file.prettySize}/#{file.prettyMaxSize}#{file.unit}</div>
+              if file.diff
+                <div class="master light"><span class="mobile">master</span> #{file.diff}</div>
+            </div>
           </div>
       </div>
     </div>


### PR DESCRIPTION

Quick question: when was the last time it was deployed? I still don't see my change from #193 when I go to the online version.

Thanks!

<!--- Provide a general summary of your changes in the Title above -->

## Description

A display which works for long path names

<!--- Describe your changes  -->

## Motivation and Context

We have a few quite long path names, for which a flat display doesnt make much sense, so I chose to go for a "vertical" display in all cases


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

before: 

<img width="1183" alt="Screenshot 2019-04-08 at 14 59 24" src="https://user-images.githubusercontent.com/6270048/55726191-7f675b00-5a0f-11e9-81fc-555da917581f.png">


after: 

<img width="1182" alt="Screenshot 2019-04-08 at 14 59 11" src="https://user-images.githubusercontent.com/6270048/55726194-842c0f00-5a0f-11e9-9b79-43beb1667f8d.png">


## Types of changes

<!--- Leave the one fitting to your PR  -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points and make sure you have done all of those -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- My code follows the code style of this project.
- If my change requires a change to the documentation I have updated the documentation accordingly.
- I have read the **CONTRIBUTING** document.
- I created an issue for the Pull Request


