### PR TITLE
Fix README.md: filename extension should be json instead of js

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can keep this array either in
 
    or in a separate file
 
-2. `bundlesize.config.js`
+2. `bundlesize.config.json`
 
    Format:
 


### PR DESCRIPTION

## Description

Fix README.md. The example in the README.md is specifying the filename as `bundlesize.config.js` but it should be `bundlesize.config.json`.

Please review and merge. Thanks~!