### PR TITLE
Make brotli optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - 'node' # latest: 12
-  - 'lts' # LTS: 10
+  - 12 # Latest
+  - 10 # LTS
   - 8
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  - 'node' # latest: 12
+  - 'lts' # LTS: 10
   - 8
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.19.0",
-    "brotli-size": "0.1.0",
     "bytes": "^3.1.0",
     "ci-env": "^1.4.0",
     "commander": "^2.20.0",
+    "compare-versions": "^3.5.0",
     "cosmiconfig": "^5.2.1",
     "github-build": "^1.2.0",
     "glob": "^7.1.4",
@@ -64,7 +64,8 @@
     "babel-preset-es2015": "^7.0.0-beta.3",
     "babel-preset-stage-3": "^7.0.0-beta.3",
     "babel-traverse": "^7.0.0-beta.3",
-    "execa": "^2.0.1",
+    "brotli-size": "^0.1.0",
+    "execa": "^2.0.2",
     "husky": "^0.14.3",
     "lint-staged": "^7.1.1",
     "prettier": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "bytes": "^3.1.0",
     "ci-env": "^1.4.0",
     "commander": "^2.20.0",
-    "compare-versions": "^3.5.0",
     "cosmiconfig": "^5.2.1",
     "github-build": "^1.2.0",
     "glob": "^7.1.4",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "babel-preset-es2015": "^7.0.0-beta.3",
     "babel-preset-stage-3": "^7.0.0-beta.3",
     "babel-traverse": "^7.0.0-beta.3",
-    "execa": "^2.0.2",
+    "execa": "^2.0.1",
     "husky": "^0.14.3",
     "lint-staged": "^7.1.1",
     "prettier": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "babel-preset-es2015": "^7.0.0-beta.3",
     "babel-preset-stage-3": "^7.0.0-beta.3",
     "babel-traverse": "^7.0.0-beta.3",
-    "brotli-size": "^0.1.0",
     "execa": "^2.0.2",
     "husky": "^0.14.3",
     "lint-staged": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "babel-preset-es2015": "^7.0.0-beta.3",
     "babel-preset-stage-3": "^7.0.0-beta.3",
     "babel-traverse": "^7.0.0-beta.3",
+    "bundlesize-plugin-brotli": "^1.0.0",
     "execa": "^2.0.1",
     "husky": "^0.14.3",
     "lint-staged": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "babel-preset-es2015": "^7.0.0-beta.3",
     "babel-preset-stage-3": "^7.0.0-beta.3",
     "babel-traverse": "^7.0.0-beta.3",
-    "bundlesize-plugin-brotli": "^1.0.0",
     "execa": "^2.0.1",
     "husky": "^0.14.3",
     "lint-staged": "^7.1.1",

--- a/packages/bundlesize-plugin-brotli/index.js
+++ b/packages/bundlesize-plugin-brotli/index.js
@@ -1,0 +1,3 @@
+const brotliSize = require('brotli-size')
+
+module.exports = { sync: brotliSize.sync }

--- a/packages/bundlesize-plugin-brotli/package.json
+++ b/packages/bundlesize-plugin-brotli/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "bundlesize-plugin-brotli",
+  "version": "1.0.0",
+  "description": "Plugin to use brotli compression with bundlesize",
+  "main": "index.js",
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "brotli-size": "0.1.0"
+  }
+}

--- a/packages/bundlesize-plugin-brotli/readme.md
+++ b/packages/bundlesize-plugin-brotli/readme.md
@@ -1,0 +1,56 @@
+<p align="center">
+  <img src="https://cdn.rawgit.com/siddharthkp/bundlesize/master/art/logo.png" height="200px">
+  <br><br>
+  <b>Plugin to use brotli compression with bundlesize on Node < 10.6.0</b>
+  <br>
+</p>
+
+&nbsp;
+
+#### Note:
+
+If you are using Node version >= 10.16.0, you do not need this plugin.
+
+&nbsp;
+
+#### Install
+
+```sh
+npm install bundlesize-plugin-brotli --save-dev
+
+# or
+
+yarn add bundlesize-plugin-brotli --dev
+```
+
+&nbsp;
+
+#### Setting up bundlesize
+
+&nbsp;
+
+See bundlesize usage here: https://github.com/siddharthkp/bundlesize
+
+&nbsp;
+
+#### Using brotli compression
+
+&nbsp;
+
+By default, bundlesize `gzips` your build files before comparing.
+
+If you are using `brotli` instead of gzip, you can specify that with each file:
+
+```json
+{
+  "files": [
+    {
+      "path": "./build/vendor.js",
+      "maxSize": "5 kB",
+      "compression": "brotli"
+    }
+  ]
+}
+```
+
+&nbsp;

--- a/src/brotli.js
+++ b/src/brotli.js
@@ -1,0 +1,43 @@
+const compare = require('compare-versions')
+const { error } = require('prettycli')
+const zlib = require('zlib')
+
+const config = require('./config')
+
+function getBrotliSync() {
+  // Does this project want brotli compression?
+  const needsBrotli = config.find(row => row.compression === 'brotli')
+
+  // If it doesn't, save us the trouble.
+  if (!needsBrotli) return null
+
+  // Check if the installed version of node supports brotli
+  const hasBrotli = zlib.brotliCompressSync
+  if (hasBrotli) return nativeBrotliSync
+
+  // Looks like this version of node does not have brotli
+  // We recommend using bundlesize-plugin-brotli which acts
+  // like a polyfill
+
+  try {
+    const polyfill = require('bundlesize-plugin-brotli')
+    // if the user has installed the plugin, we can safely return it
+    return polyfill
+  } catch (err) {
+    // if they haven't, show them an error and exit with error code 1
+    const message = `Missing dependency: bundlesize-plugin-brotli
+
+  To use compression: brotli, please install bundlesize-plugin-brotli as a dev dependency.
+
+  You can read about the compression options here:
+  https://github.com/siddharthkp/bundlesize#customisation`
+
+    error(message, { silent: true })
+  }
+}
+
+function nativeBrotliSync(input) {
+  return zlib.brotliCompressSync(input).length
+}
+
+module.exports = { sync: getBrotliSync() }

--- a/src/brotli.js
+++ b/src/brotli.js
@@ -21,7 +21,7 @@ function getBrotliSync() {
   try {
     const polyfill = require('bundlesize-plugin-brotli')
     // if the user has installed the plugin, we can safely return it
-    return polyfill
+    return polyfill.sync
   } catch (err) {
     // if they haven't, show them an error and exit with error code 1
     if (err && err.code === 'MODULE_NOT_FOUND') {

--- a/src/brotli.js
+++ b/src/brotli.js
@@ -1,4 +1,3 @@
-const compare = require('compare-versions')
 const { error } = require('prettycli')
 const zlib = require('zlib')
 

--- a/src/brotli.js
+++ b/src/brotli.js
@@ -24,7 +24,8 @@ function getBrotliSync() {
     return polyfill
   } catch (err) {
     // if they haven't, show them an error and exit with error code 1
-    const message = `Missing dependency: bundlesize-plugin-brotli
+    if (err && err.code === 'MODULE_NOT_FOUND') {
+      const message = `Missing dependency: bundlesize-plugin-brotli
 
   To use brotli with Node versions lower than v10.16.0,
   please install bundlesize-plugin-brotli as a dev dependency.
@@ -32,7 +33,11 @@ function getBrotliSync() {
   You can read about the compression options here:
   https://github.com/siddharthkp/bundlesize#customisation`
 
-    error(message, { silent: true })
+      error(message, { silent: true })
+    } else {
+      // if it's a different error, show the raw error
+      error(err, { silent: true })
+    }
   }
 }
 

--- a/src/brotli.js
+++ b/src/brotli.js
@@ -27,7 +27,8 @@ function getBrotliSync() {
     // if they haven't, show them an error and exit with error code 1
     const message = `Missing dependency: bundlesize-plugin-brotli
 
-  To use compression: brotli, please install bundlesize-plugin-brotli as a dev dependency.
+  To use brotli with Node versions lower than v10.16.0,
+  please install bundlesize-plugin-brotli as a dev dependency.
 
   You can read about the compression options here:
   https://github.com/siddharthkp/bundlesize#customisation`

--- a/src/compressed-size.js
+++ b/src/compressed-size.js
@@ -1,5 +1,5 @@
 const gzip = require('gzip-size')
-const brotli = require('brotli-size')
+const brotli = require('./brotli')
 
 const getCompressedSize = (data, compression = 'gzip') => {
   let size


### PR DESCRIPTION
## Motivation and Context

From the looks of it, `iltorb`'s native bindings are large + don't play well on all platforms - and fails installs on windows and some CI environments.

1. For folks not using brotli compression at all, this is unnecessary overhead.
2. Native brotli compression support landed in node 10.16.0 (LTS), we don't need to include an external dependency for that
3. For folks using brotli and node < 10.16.0, this PR **is a breaking change** and will ask them to install `bundlesize-plugin-brotli` to continue

<!--- Describe your changes  -->

Changes introduced in this PR:

1. Remove `brotli-size` from dependencies

2. On Node >= 10.6.0, use `zlib.brotliCompressSync`

3. On Node < 10.6.0, ask to install `bundlesize-plugin-brotli`

4. Introduces `bundlesize-plugin-brotli`


<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #202, #283 and #213

Prior work: #220 #299