### PR TITLE
feat: Add option --report-json

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -20,6 +20,7 @@ program
     '-c, --compression [compression]',
     'specify which compression algorithm to use'
   )
+  .option('--report-json', 'output json')
   .parse(process.argv)
 
 let configFromCli

--- a/src/report-json.js
+++ b/src/report-json.js
@@ -1,0 +1,12 @@
+const fs = require('fs')
+
+let report = false
+if (process.argv.indexOf('--report-json') !== -1) report = true
+
+const reportJson = results => {
+  if(report){
+    fs.writeFileSync('bundlesize-report.json', JSON.stringify(results,null,2))
+  }
+}
+
+module.exports = reportJson

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -5,6 +5,7 @@ const build = require('./build')
 const api = require('./api')
 const debug = require('./debug')
 const shortener = require('./shortener')
+const reportJson = require('./report-json')
 
 const setBuildStatus = ({
   url,
@@ -93,14 +94,14 @@ const analyse = ({ files, masterValues }) => {
       else if size > master, warn + pass
       else yay + pass
     */
-
+   
     if (size > maxSize) {
       fail = true
       if (prettySize) message += `> maxSize ${prettySize} ${compressionText}`
-      error(message, { fail: false, label: 'FAIL' })
+      if (process.argv.indexOf('--report-json') === -1) error(message, { fail: false, label: 'FAIL' })
     } else if (!master) {
       if (prettySize) message += `< maxSize ${prettySize} ${compressionText}`
-      info('PASS', message)
+      if (process.argv.indexOf('--report-json') === -1) info('PASS', message)
     } else {
       if (prettySize) message += `< maxSize ${prettySize} ${compressionText}`
       const diff = size - master
@@ -159,8 +160,11 @@ const compare = (files, masterValues = {}) => {
     totalMaxSize: results.reduce((acc, result) => acc + result.maxSize, 0)
   })
 
-  let fail = results.filter(result => result.fail).length > 0
+  let fail;
+  if (process.argv.indexOf('--report-json') === -1) fail = results.filter(result => result.fail).length > 0
+  reportJson(results);
   report({ files, globalMessage, fail })
+  
 }
 
 const reporter = files => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When run`npm run bundlesize --report-json`, output file `bundlesize-report.json` in working directory.

<!--- Describe your changes  -->

## Motivation and Context
We can edit data made from bundlesize

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of changes

<!--- Leave the one fitting to your PR  -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!--- Go over all the following points and make sure you have done all of those -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- My code follows the code style of this project.
- If my change requires a change to the documentation I have updated the documentation accordingly.
  - I’m thinking about whether to add this option for README.md.
- I have read the **CONTRIBUTING** document.
- I created an issue for the Pull Request
Closes #322 
