### PR TITLE
Add CI env to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,12 +183,13 @@ Currently works with [Travis CI](https://travis-ci.org), [CircleCI](https://circ
 - [Authorize `bundlesize` for status access](https://github.com/login/oauth/authorize?scope=repo%3Astatus&client_id=6756cb03a8d6528aca5a), copy the token provided.
 - Add this token as `BUNDLESIZE_GITHUB_TOKEN` as environment parameter in your CIs project settings.
 
-Using a different CI? You will need to supply an additional 4 environment variables.
+Using a different CI? You will need to supply an additional 5 environment variables.
 
 - `CI_REPO_OWNER` given the repo `https://github.com/myusername/myrepo` would be `myusername`
 - `CI_REPO_NAME` given the repo `https://github.com/myusername/myrepo` would be `myrepo`
 - `CI_COMMIT_MESSAGE` the commit message
 - `CI_COMMIT_SHA` the SHA of the CI commit, in [Jenkins](https://jenkins.io/) you would use `${env.GIT_COMMIT}`
+- `CI=true` usually set automtically in CI enviroments 
 
 (Ask me for help if you're stuck)
 


### PR DESCRIPTION
Added a note about requiring the `CI` env variable to be se.

## Description

Updated the readme to include more information on running bundlesize on different CI platforms

## Motivation and Context

I wanted to test bundlesize locally so set the env vars locally to run the command.
The script failed as the env vars are not picked up unless `CI=true`

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- I have read the **CONTRIBUTING** document. ✅ 
- I created an issue for the Pull Request fixes #329
