### PR TITLE
Fixed broken link in github token missing warning

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -17,7 +17,7 @@ else if (ci) {
   // warn(`github token not found
   //
   //   You are missing out on some cool features.
-  //   Read more here: https://github.com/siddharthkp/bundlesize#2-build-status
+  //   Read more here: https://github.com/siddharthkp/bundlesize#build-status-for-github
   // `)
 }
 


### PR DESCRIPTION
## Description

Fixes a broken link in one of the warning messages (currently commented though)

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
