### PR TITLE
Remove GITHUB_TOKEN from token.js

### DIFF
--- a/src/token.js
+++ b/src/token.js
@@ -1,7 +1,5 @@
 const token =
   process.env.bundlesize_github_token ||
-  process.env.BUNDLESIZE_GITHUB_TOKEN ||
-  process.env.github_token ||
-  process.env.GITHUB_TOKEN
+  process.env.BUNDLESIZE_GITHUB_TOKEN
 
 module.exports = token


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove the `GITHUB_TOKEN` from token.js, Instead it should only use the project specific `BUNDLESIZE_GITHUB_TOKEN` 

<!--- Describe your changes  -->

## Motivation and Context
This was causing an error with generic CI tokens, #93

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- Leave the one fitting to your PR  -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points and make sure you have done all of those -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] If my change requires a change to the documentation I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I created an issue for the Pull Request
