### PR TITLE
Add support for node versions 12.x and above

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.21.1",
-    "brotli-size": "0.1.0",
+    "brotli-size": "4.0.0",
     "bytes": "^3.1.0",
     "ci-env": "^1.4.0",
     "commander": "^2.20.0",


### PR DESCRIPTION
## Description
Unable to use this package with node versions > 10.16.0. 

## Motivation and Context
Unable to upgrade the node versions because of the iltorb dependency.

<!--- Why is this change required? What problem does it solve? -->
The iltorb module is deprecated in favour of zlib starting with Node.js v10.16.0 (https://www.npmjs.com/package/iltorb). Upgrading the brotli-size package to v4.0.0 as it no longer depends on the iltorb package.

https://github.com/siddharthkp/bundlesize/issues/374

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to change)
