### PR TITLE
Migrate now.sh endpoint to vercel.app

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -6,7 +6,7 @@ const { warn } = require('prettycli')
 const token = require('./token')
 const debug = require('./debug')
 
-const url = 'https://bundlesize-store.now.sh/values'
+const url = 'https://bundlesize-store.vercel.app/values'
 
 let enabled = false
 

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -132,7 +132,7 @@ const report = ({ files, globalMessage, fail }) => {
   const params = encodeURIComponent(
     JSON.stringify({ files, repo, branch, commit_message, sha })
   )
-  let url = `https://bundlesize-store.now.sh/build?info=${params}`
+  let url = `https://bundlesize-store.vercel.app/build?info=${params}`
 
   debug('url before shortening', url)
 


### PR DESCRIPTION
`now.sh` domain and websites stopped working now, most of them seem to be automatically migrated to `vercel.app`.

## Description

This is breaking builds in GitHub CI.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of changes

<!--- Leave the one fitting to your PR  -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points and make sure you have done all of those -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- My code follows the code style of this project.
- If my change requires a change to the documentation I have updated the documentation accordingly.
- I have read the **CONTRIBUTING** document.
- I created an issue for the Pull Request

Closes  #390